### PR TITLE
Remember previous context

### DIFF
--- a/src/alure.pxd
+++ b/src/alure.pxd
@@ -248,6 +248,8 @@ cdef extern from 'alure2.h' namespace 'alure' nogil:
 
         void destroy() except +
 
+        Device get_device 'getDevice'() except +
+
         void start_batch 'startBatch'() except +
         void end_batch 'endBatch'() except +
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,39 @@
+# Source pytest module
+# Copyright (C) 2020  Ngô Ngọc Đức Huy
+#
+# This file is part of palace.
+#
+# palace is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License,
+# or (at your option) any later version.
+#
+# palace is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with palace.  If not, see <https://www.gnu.org/licenses/>.
+
+"""This pytest module tries to test the correctness of the class Context."""
+
+from palace import Context, current_context
+
+
+def test_with_context(device):
+    """Test if `with` can be used to start a context
+    and is destroyed properly.
+    """
+    with Context(device) as context:
+        assert current_context() == context
+
+
+def test_nested_context_manager(device):
+    """Test if the context manager returns to the
+    previous context.
+    """
+    with Context(device) as ctx:
+        with Context(device):
+            pass
+        assert current_context() == ctx


### PR DESCRIPTION
I try to resolve #30 by saving context into a static stack-list `current_context` (maybe I should rename it to `current_contexts`) in which the top (last) item is the current context. When a context is destroyed (`__exit__`), it's popped and the latest previous context will be loaded into `use_context`.