### PR TITLE
Add wave example and solve BaseDecoder deadlock

### DIFF
--- a/examples/palace-wave.py
+++ b/examples/palace-wave.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# HRTF rendering example using ALC_SOFT_HRTF extension
+# Copyright (C) 2020  Nguyễn Gia Phong
+#
+# This file is part of palace.
+#
+# palace is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License,
+# or (at your option) any later version.
+#
+# palace is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with palace.  If not, see <https://www.gnu.org/licenses/>.
+
+import wave
+from argparse import ArgumentParser
+from datetime import datetime, timedelta
+from itertools import count, takewhile
+from sys import stderr
+from time import sleep
+from typing import Iterable, Tuple
+
+from palace import BaseDecoder, Device, Context, Source
+
+CHUNK_LEN: int = 12000
+QUEUE_SIZE: int = 4
+PERIOD: float = 0.025
+
+
+class WaveDecoder(BaseDecoder):
+    def __init__(self, file: str) -> None: self.wave = wave.open(file, 'r')
+
+    @BaseDecoder.frequency.getter
+    def frequency(self) -> int: return self.wave.getframerate()
+
+    @BaseDecoder.channel_config.getter
+    def channel_config(self) -> str:
+        n = self.wave.getnchannels()
+        if n == 1: return 'Mono'
+        if n == 2: return 'Stereo'
+
+    @BaseDecoder.sample_type.getter
+    def sample_type(self) -> str:
+        n = self.wave.getsampwidth()
+        if n == 1: return 'Unsigned 8-bit'
+        if n == 2: return 'Signed 16-bit'
+
+    @BaseDecoder.length.getter
+    def length(self) -> int: return self.wave.getnframes()
+
+    def seek(self, pos: int) -> bool:
+        try:
+            self.wave.setpos(pos)
+        except wave.Error:
+            return False
+        else:
+            return True
+
+    @BaseDecoder.loop_points.getter
+    def loop_points(self) -> Tuple[int, int]: return 0, 0
+
+    def read(self, count: int) -> bytes: return self.wave.readframes(count)
+
+
+def pretty_time(seconds: float) -> str:
+    """Return human-readably formatted time."""
+    time = datetime.min + timedelta(seconds=seconds)
+    if seconds < 3600: return time.strftime('%M:%S')
+    return time.strftime('%H:%M:%S')
+
+
+def play(files: Iterable[str], device: str) -> None:
+    with Device(device, fail_safe=True) as dev:
+        print('Opened', dev.name['full'])
+        for filename in files:
+            try:
+                decoder = WaveDecoder(filename)
+            except FileNotFoundError:
+                stderr.write(f'Failed to open file: {filename}\n')
+                continue
+            with Context(dev) as ctx, Source(ctx) as src:
+                decoder.play(src, CHUNK_LEN, QUEUE_SIZE)
+                print(f'Playing {filename} ({decoder.sample_type},',
+                      f'{decoder.channel_config}, {decoder.frequency} Hz)')
+
+                for i in takewhile(lambda i: src.playing, count()):
+                    print(f' {pretty_time(src.offset_seconds)} /'
+                          f' {pretty_time(decoder.length_seconds)}',
+                          end='\r', flush=True)
+                    sleep(PERIOD)
+                    ctx.update()
+                print()
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.add_argument('files', nargs='+', help='WAV audio files')
+    parser.add_argument('-d', '--device', default='', help='device name')
+    args = parser.parse_args()
+    play(args.files, args.device)


### PR DESCRIPTION
This PR is created as a playground to solve `BaseDecoder` GIL deadlock.  The wave example is provided as an ultimate test if any error occur using the interface.  To test, use a fairly long WAV audio like [this one](https://commons.wikimedia.org/wiki/File:Drozerix_-_Computer_Adventures.wav), since the error may only occurs after quite a few seconds.

<details><summary>Background information</summary><p>

Some background on the implementation of `BaseDecoder`:  `alure::Decoder` is created as a interface for users to derive their own decoders.  Alure API takes a smart pointer of its instance to access functionalities like `read`, `seek`, etc.  To expose such interface, [the following was done](https://github.com/McSinyx/palace/commit/d7ad609ad9f6d1e8b0dc748ac4cb9a331d75832d):
* Subclass `alure::Decoder` to `palace::BaseDecoder`, simply because Cython does not support `noexcept`, and we need matching method definition
* Create a Python abstract base class called `BaseDecoder`, which does nothing but declaring methods analogous to `alure::Decoder`'s
* Create a C++ class `CppDecoder` based on `palace::BaseDecoder`, which call the Cython extension class `Decoder`'s methods.  Because of this, `CppDecoder` must enable GIL.
* Create a Cython extension class `_BaseDecoder` with a pointer to `CppDecoder`, which in turn calls the same `_BaseDecoder` instance's methods
* Make `BaseDecoder` a subclass of `_BaseDecoder` and the later a subclass of `Decoder`.

So what happens when a `BaseDecoder` instance is used for playback is that:
0. Palace calls alure API to update the context
1. Alure context then tries to update the playing source
2. Alure source asks the `CppDecoder` to `read`
3. `CppDecoder`'s method calls `BaseDecoder`'s one

</p></details>

Now, both `CppDecoder` and `BaseDecoder` needs to aquire the GIL to run.  Since `CppDecoder` is not running on the main thread where `BaseDecoder` (`WaveDecoder` to be exact) exists, I imagine in step 3,
* `WaveDecoder` wait for the GIL to be release to do its job
* `CppDecoder` wait for `WaveDecoder` to finish to release the GIL

Since I'm terrible at threaded programming, I might very likely to be wrong though.  What really happens is that with 2956a687d64127d432e13ab3327e0122d9cc1bfa, at one point, the playback will hang forever and must be killed with force.

One might notice that it is unnecessary for `CppDecoder.read` to [acquire the GIL manually](https://github.com/McSinyx/palace/blob/2956a687d64127d432e13ab3327e0122d9cc1bfa/src/palace.pyx#L1711), but only to allow its statements to do it.  Apply the following patch
<details><summary>No GIL patch</summary><p>

```diff
diff --git a/src/palace.pyx b/src/palace.pyx
index 841b5f6..809a1a0 100644
--- a/src/palace.pyx
+++ b/src/palace.pyx
@@ -1708,7 +1708,7 @@ cdef cppclass CppDecoder(alure.BaseDecoder):
 
     # FIXME: dead-global-interpreter-lock
     # Without GIL Context.update causes segfault.
-    unsigned read_(void* ptr, unsigned count) with gil:
+    unsigned read_(void* ptr, unsigned count):
         cdef string samples = pyo.read(count)
         memcpy(ptr, samples.c_str(), samples.size())
         return alure.bytes_to_frames(
```

</p></details>
and I got either one of these
<details><summary>Segmentation fault</summary><p>

```gdb
(gdb) run examples/palace-wave.py ~/Music/Computer\ Adventures.wav
Starting program: /usr/bin/python3 examples/palace-wave.py ~/Music/Computer\ Adventures.wav
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[New Thread 0x7ffff63e5700 (LWP 1194989)]
[New Thread 0x7ffff63e5700 (LWP 1194990)]
[Thread 0x7ffff63e5700 (LWP 1194989) exited]
[Thread 0x7ffff63e5700 (LWP 1194990) exited]
[New Thread 0x7ffff63e5700 (LWP 1194991)]
[Thread 0x7ffff63e5700 (LWP 1194991) exited]
[New Thread 0x7ffff63e5700 (LWP 1194992)]
Opened Built-in Audio Analog Stereo
[New Thread 0x7ffff1be4700 (LWP 1194993)]
[New Thread 0x7ffff11bc700 (LWP 1194994)]
[New Thread 0x7ffff0fbb700 (LWP 1194995)]
Playing /home/cnx/Music/Computer Adventures.wav (Signed 16-bit, Stereo, 48000 Hz)
 00:00 / 02:49
Thread 8 "python3" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7ffff0fbb700 (LWP 1194995)]
0x000000000053b3b6 in _PyEval_EvalFrameDefault ()
(gdb) bt
#0  0x000000000053b3b6 in _PyEval_EvalFrameDefault ()
#1  0x0000000000539846 in _PyEval_EvalCodeWithName ()
#2  0x00000000005cc788 in _PyFunction_FastCallKeywords ()
#3  0x0000000000538ae0 in ?? ()
#4  0x000000000053ba12 in _PyEval_EvalFrameDefault ()
#5  0x0000000000539846 in _PyEval_EvalCodeWithName ()
#6  0x00000000005cc788 in _PyFunction_FastCallKeywords ()
#7  0x0000000000538ae0 in ?? ()
#8  0x000000000053ba12 in _PyEval_EvalFrameDefault ()
#9  0x00000000005cc48b in _PyFunction_FastCallKeywords ()
#10 0x0000000000538ae0 in ?? ()
#11 0x000000000053ba12 in _PyEval_EvalFrameDefault ()
#12 0x00007ffff751cca8 in __Pyx_PyFunction_FastCallNoKw (co=co@entry=0x7ffff772bf60, 
    args=<optimized out>, args@entry=0x7ffff0fba970, na=na@entry=2, globals=0x7ffff78b9e10)
    at src/palace.cpp:35664
#13 0x00007ffff753cbcf in __Pyx_PyFunction_FastCallDict (kwargs=0x0, nargs=2, args=0x7ffff0fba970, 
    func=0x7ffff7654ef0) at src/palace.cpp:35695
#14 __Pyx_PyObject_FastCall (func=0x7ffff7654ef0, args=0x7ffff0fba970, nargs=2) at src/palace.cpp:35830
#15 0x00007ffff756b899 in __pyx_t_6palace_CppDecoder::read_ (this=0xa2d2d0, __pyx_v_ptr=0xa68400, 
    __pyx_v_count=<optimized out>) at src/palace.cpp:23618
#16 0x00007ffff75713da in palace::BaseDecoder::read (this=<optimized out>, ptr=<optimized out>, 
    count=<optimized out>) at src/bases.h:73
#17 0x00007ffff7441cac in alure::ALBufferStream::streamMoreData(unsigned int, bool) ()
   from /usr/local/lib/libalure2.so
#18 0x00007ffff743c315 in alure::SourceImpl::refillBufferStream() () from /usr/local/lib/libalure2.so
#19 0x00007ffff743c35e in alure::SourceImpl::updateAsync() () from /usr/local/lib/libalure2.so
#20 0x00007ffff7404000 in alure::ContextImpl::backgroundProc()::{lambda(alure::SourceImpl*)#1}::operator()(alure::SourceImpl*) const () from /usr/local/lib/libalure2.so
```

</p></details>
<details><summary>PyEval_SaveThread: NULL tstate</summary><p>

```gdb
(gdb) run examples/palace-wave.py ~/Music/Computer\ Adventures.wav
Starting program: /usr/bin/python3 examples/palace-wave.py ~/Music/Computer\ Adventures.wav
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[New Thread 0x7ffff63e5700 (LWP 1192000)]
[New Thread 0x7ffff63e5700 (LWP 1192001)]
[Thread 0x7ffff63e5700 (LWP 1192000) exited]
[Thread 0x7ffff63e5700 (LWP 1192001) exited]
[New Thread 0x7ffff63e5700 (LWP 1192002)]
[Thread 0x7ffff63e5700 (LWP 1192002) exited]
[New Thread 0x7ffff63e5700 (LWP 1192003)]
Opened Built-in Audio Analog Stereo
[New Thread 0x7ffff1be4700 (LWP 1192004)]
[New Thread 0x7ffff11bc700 (LWP 1192005)]
[New Thread 0x7ffff0fbb700 (LWP 1192006)]
Playing /home/cnx/Music/Computer Adventures.wav (Signed 16-bit, Stereo, 48000 Hz)
Fatal Python error: PyEval_SaveThread: NULL tstate

Thread 0x00007ffff7c26740 (most recent call first):
  File "/usr/lib/python3.7/chunk.py", line 136 in read
  File "/usr/lib/python3.7/chunk.py", line 136 in read
  File "/usr/lib/python3.7/wave.py", line 243 in readframes
  File "examples/palace-wave.py", line 73 in pretty_time
  File "examples/palace-wave.py", line 95 in play
  File "examples/palace-wave.py", line 105 in <module>

Thread 8 "python3" received signal SIGABRT, Aborted.
[Switching to Thread 0x7ffff0fbb700 (LWP 1192006)](gdb) run examples/palace-wave.py ~/Music/Computer\ Adventures.wav
The program being debugged has been started already.
Start it from the beginning? (y or n) y
Starting program: /usr/bin/python3 examples/palace-wave.py ~/Music/Computer\ Adventures.wav
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[New Thread 0x7ffff63e5700 (LWP 1192000)]
[New Thread 0x7ffff63e5700 (LWP 1192001)]
[Thread 0x7ffff63e5700 (LWP 1192000) exited]
[Thread 0x7ffff63e5700 (LWP 1192001) exited]
[New Thread 0x7ffff63e5700 (LWP 1192002)]
[Thread 0x7ffff63e5700 (LWP 1192002) exited]
[New Thread 0x7ffff63e5700 (LWP 1192003)]
Opened Built-in Audio Analog Stereo
[New Thread 0x7ffff1be4700 (LWP 1192004)]
[New Thread 0x7ffff11bc700 (LWP 1192005)]
[New Thread 0x7ffff0fbb700 (LWP 1192006)]
Playing /home/cnx/Music/Computer Adventures.wav (Signed 16-bit, Stereo, 48000 Hz)
Fatal Python error: PyEval_SaveThread: NULL tstate

Thread 0x00007ffff7c26740 (most recent call first):
  File "/usr/lib/python3.7/chunk.py", line 136 in read
  File "/usr/lib/python3.7/chunk.py", line 136 in read
  File "/usr/lib/python3.7/wave.py", line 243 in readframes
  File "examples/palace-wave.py", line 73 in pretty_time
  File "examples/palace-wave.py", line 95 in play
  File "examples/palace-wave.py", line 105 in <module>

Thread 8 "python3" received signal SIGABRT, Aborted.
[Switching to Thread 0x7ffff0fbb700 (LWP 1192006)]
(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007ffff7e0a535 in __GI_abort () at abort.c:79
#2  0x000000000048a4cd in ?? ()
#3  0x000000000048a540 in Py_FatalError ()
#4  0x000000000047f272 in ?? ()
#5  0x0000000000616758 in ?? ()
#6  0x00000000005cb728 in _PyMethodDef_RawFastCallDict ()
#7  0x00000000005c9de8 in ?? ()
#8  0x00000000005cad79 in PyObject_CallMethodObjArgs ()
#9  0x000000000061acbf in ?? ()
#10 0x000000000061cebf in ?? ()
#11 0x00000000004dbf59 in _PyMethodDescr_FastCallKeywords ()
#12 0x0000000000538bb6 in ?? ()
#13 0x000000000053ba12 in _PyEval_EvalFrameDefault ()
#14 0x0000000000539846 in _PyEval_EvalCodeWithName ()
#15 0x00000000005cc788 in _PyFunction_FastCallKeywords ()
#16 0x0000000000538ae0 in ?? ()
#17 0x000000000053ba12 in _PyEval_EvalFrameDefault ()
#18 0x0000000000539846 in _PyEval_EvalCodeWithName ()
#19 0x00000000005cc788 in _PyFunction_FastCallKeywords ()
#20 0x0000000000538ae0 in ?? ()
#21 0x000000000053ba12 in _PyEval_EvalFrameDefault ()
#22 0x00000000005cc48b in _PyFunction_FastCallKeywords ()
#23 0x0000000000538ae0 in ?? ()
#24 0x000000000053ba12 in _PyEval_EvalFrameDefault ()
#25 0x00007ffff751cca8 in __Pyx_PyFunction_FastCallNoKw (co=co@entry=0x7ffff772bf60, 
    args=<optimized out>, args@entry=0x7ffff0fba970, na=na@entry=2, globals=0x7ffff78b9e10)
    at src/palace.cpp:35664
#26 0x00007ffff753cbcf in __Pyx_PyFunction_FastCallDict (kwargs=0x0, nargs=2, args=0x7ffff0fba970, 
    func=0x7ffff7654ef0) at src/palace.cpp:35695
#27 __Pyx_PyObject_FastCall (func=0x7ffff7654ef0, args=0x7ffff0fba970, nargs=2) at src/palace.cpp:35830
#28 0x00007ffff756b899 in __pyx_t_6palace_CppDecoder::read_ (this=0xa25430, __pyx_v_ptr=0xa68440, 
    __pyx_v_count=<optimized out>) at src/palace.cpp:23618
#29 0x00007ffff75713da in palace::BaseDecoder::read (this=<optimized out>, ptr=<optimized out>, 
    count=<optimized out>) at src/bases.h:73
#30 0x00007ffff7441cac in alure::ALBufferStream::streamMoreData(unsigned int, bool) ()
   from /usr/local/lib/libalure2.so
#31 0x00007ffff743c315 in alure::SourceImpl::refillBufferStream() () from /usr/local/lib/libalure2.so
#32 0x00007ffff743c35e in alure::SourceImpl::updateAsync() () from /usr/local/lib/libalure2.so
#33 0x00007ffff7404000 in alure::ContextImpl::backgroundProc()::{lambda(alure::SourceImpl*)#1}::operator()(alure::SourceImpl*) const () from /usr/local/lib/libalure2.so
```

</p></details>
<details><summary>PyThreadState_Get: no current thread</summary><p>

```
$ examples/palace-wave.py ~/Music/Computer\ Adventures.wav 
Opened Built-in Audio Analog Stereo
Playing /home/cnx/Music/Computer Adventures.wav (Signed 16-bit, Stereo, 48000 Hz)
Fatal Python error: PyThreadState_Get: no current thread

Thread 0x00007fb952c85740 (most recent call first):
  File "examples/palace-wave.py", line 95 in play
  File "examples/palace-wave.py", line 105 in <module>
Aborted
```
I can't get gdb to catch this one though.

</p></details>
I believe they are exactly the same error but not sure how to solve the issue.  Any input is appreciated.