### PR TITLE
Fixing some small mistakes made in 9de664a

### DIFF
--- a/src/palace.pyx
+++ b/src/palace.pyx
@@ -2010,7 +2010,7 @@ cdef class BaseEffect:
         return <boolean> self.slot and <boolean> self.impl
 
     @setter
-    def gain(self, value: float) -> None:
+    def slot_gain(self, value: float) -> None:
         """Gain of the effect slot."""
         self.slot.set_gain(value)
 

--- a/src/palace.pyx
+++ b/src/palace.pyx
@@ -76,7 +76,7 @@ __all__ = [
     'thread_local', 'current_context', 'use_context',
     'cache', 'free', 'decode', 'sample_size', 'sample_length',
     'Device', 'Context', 'Listener', 'Buffer', 'Source', 'SourceGroup',
-    'Effect', 'ReverbEffect', 'ChorusEffect',
+    'BaseEffect', 'ReverbEffect', 'ChorusEffect',
     'Decoder', 'BaseDecoder', 'FileIO', 'MessageHandler']
 
 from abc import abstractmethod, ABCMeta

--- a/tests/unit/test_effect.py
+++ b/tests/unit/test_effect.py
@@ -23,14 +23,14 @@ from palace import BaseEffect, ReverbEffect, Source
 from pytest import raises
 
 
-def test_gain(context):
-    """Test write-only property gain."""
+def test_slot_gain(context):
+    """Test write-only property slot_gain."""
     with BaseEffect() as fx:
-        fx.gain = 0
-        fx.gain = 1
-        fx.gain = 5/7
-        with raises(ValueError): fx.gain = 7/5
-        with raises(ValueError): fx.gain = -1
+        fx.slot_gain = 0
+        fx.slot_gain = 1
+        fx.slot_gain = 5/7
+        with raises(ValueError): fx.slot_gain = 7/5
+        with raises(ValueError): fx.slot_gain = -1
 
 
 def test_source_sends(context):


### PR DESCRIPTION
In this PR, I fix two mistakes made in 9de664a, particularly:

- Rename `BaseEffect.gain` to `BaseEffect.slot_gain` to avoid shadowing from `ReverbEffect.gain`
- Editing `Effect` in `__all__` to `BaseEffect` since the class is renamed.