### PR TITLE
Build wheels for CPython 3.9

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9.0-beta.4 - 3.9.0
+        python-version: 3.9
 
     - name: Checkout palace
       uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9.0-beta.4 - 3.9.0
+        python-version: 3.9
 
     - name: Install tox
       run: python -m pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,13 @@ jobs:
       language: shell
       env: CIBW_BUILD=cp36-macosx_x86_64
     - services: docker
-      env: CIBW_BUILD=cp36-manylinux_x86_64
+      env: CIBW_BUILD="cp36-manylinux_x86_64 cp36-manylinux_aarch64"
     - services: docker
-      env: CIBW_BUILD=cp37-manylinux_x86_64
+      env: CIBW_BUILD="cp37-manylinux_x86_64 cp37-manylinux_aarch64"
     - services: docker
-      env: CIBW_BUILD=cp38-manylinux_x86_64
+      env: CIBW_BUILD="cp38-manylinux_x86_64 cp38-manylinux_aarch64"
+    - services: docker
+      env: CIBW_BUILD="cp39-manylinux_x86_64 cp39-manylinux_aarch64"
 
 script: python3 -m cibuildwheel --output-dir=dist
 


### PR DESCRIPTION
Let the CI run!  Edit: apparently SciPy hasn't provided wheels for CPython 3.9 yet :disappointed: